### PR TITLE
chore: update release dry-run workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
   dryrun:
     if: ${{ github.ref != 'refs/heads/main' || github.event.inputs.release != 'release' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
+      pull-requests: read
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Mostly to lock down the workflow permissions a bit more.