### PR TITLE
fix: style `new` keywords with bright orange

### DIFF
--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -104,7 +104,7 @@ export default makeTheme({
     'keyword.operator.spread': darkTheme.text.quaternary,
     'keyword.operator.type.annotation': darkTheme.text.quaternary,
     'keyword.operator.ternary': darkTheme.text.tertiary,
-    'keyword.operator.new': palette.dark.orange9,
+    'keyword.operator.new': palette.dark.orange10,
 
     'meta.brace': darkTheme.text.quaternary,
     'meta.definition.variable': darkTheme.text.default,

--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -104,6 +104,7 @@ export default makeTheme({
     'keyword.operator.spread': darkTheme.text.quaternary,
     'keyword.operator.type.annotation': darkTheme.text.quaternary,
     'keyword.operator.ternary': darkTheme.text.tertiary,
+    'keyword.operator.new': palette.dark.orange9,
 
     'meta.brace': darkTheme.text.quaternary,
     'meta.definition.variable': darkTheme.text.default,


### PR DESCRIPTION
![image](https://github.com/expo/vscode-expo-theme/assets/1203991/5e021f7b-4216-480f-baa3-086796cdb122)

`new` should be orange :)