### PR TITLE
fix: use proper colors for keyword expressions

### DIFF
--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -104,6 +104,7 @@ export default makeTheme({
     'keyword.operator.spread': darkTheme.text.quaternary,
     'keyword.operator.type.annotation': darkTheme.text.quaternary,
     'keyword.operator.ternary': darkTheme.text.tertiary,
+    'keyword.operator.new': palette.dark.orange10,
 
     'meta.brace': darkTheme.text.quaternary,
     'meta.definition.variable': darkTheme.text.default,

--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -84,7 +84,7 @@ export default makeTheme({
 
     'editorBracketMatch.border': darkTheme.text.quaternary,
 
-    'entity.name.tag': palette.dark.orange9,
+    'entity.name.tag': palette.dark.orange10,
     'entity.name.type': palette.dark.green11,
     'entity.name.type.class': palette.dark.blue11,
     'entity.name.type.module': palette.dark.blue11,
@@ -94,11 +94,11 @@ export default makeTheme({
 
     'keyword.control': palette.dark.purple11,
     'keyword.control.flow': palette.dark.pink10,
-    'keyword.control.new': palette.dark.orange9,
+    'keyword.control.new': palette.dark.orange10,
     'keyword.other': palette.dark.pink10,
     'keyword.operator': darkTheme.text.tertiary,
     'keyword.operator.assignment': darkTheme.text.quaternary,
-    'keyword.operator.expression.keyof': palette.dark.pink10,
+    'keyword.operator.expression': palette.dark.orange10,
     'keyword.operator.logical': darkTheme.text.tertiary,
     'keyword.operator.rest': darkTheme.text.quaternary,
     'keyword.operator.spread': darkTheme.text.quaternary,
@@ -135,8 +135,8 @@ export default makeTheme({
     'string.quoted': palette.dark.yellow11,
     'string.template': palette.dark.yellow11,
 
-    'support.type.primitive': palette.dark.orange9,
-    'support.type.property-name': palette.dark.orange9,
+    'support.type.primitive': palette.dark.orange10,
+    'support.type.property-name': palette.dark.orange10,
     'support.type.builtin': palette.dark.pink10,
 
     'variable.object.property': darkTheme.text.default,

--- a/src/themes/expo-light.ts
+++ b/src/themes/expo-light.ts
@@ -104,7 +104,7 @@ export default makeTheme({
     'keyword.other': palette.light.pink10,
     'keyword.operator': lightTheme.text.tertiary,
     'keyword.operator.assignment': lightTheme.text.quaternary,
-    'keyword.operator.expression.keyof': palette.light.pink10,
+    'keyword.operator.expression': palette.light.orange10,
     'keyword.operator.logical': lightTheme.text.tertiary,
     'keyword.operator.rest': lightTheme.text.quaternary,
     'keyword.operator.spread': lightTheme.text.quaternary,

--- a/src/themes/expo-light.ts
+++ b/src/themes/expo-light.ts
@@ -110,6 +110,7 @@ export default makeTheme({
     'keyword.operator.spread': lightTheme.text.quaternary,
     'keyword.operator.type.annotation': lightTheme.text.quaternary,
     'keyword.operator.ternary': lightTheme.text.tertiary,
+    'keyword.operator.new': palette.dark.orange10,
 
     'meta.brace': lightTheme.text.quaternary,
     'meta.definition.variable': lightTheme.text.default,


### PR DESCRIPTION
# Why & How

It looks like at some point we missed that keyword expressions are overwritten by parent style, let's address that.

Additionally, I have tweak the orange shade used in dark theme.

# Preview

<img width="758" alt="Screenshot 2023-07-25 at 11 26 26" src="https://github.com/expo/vscode-expo-theme/assets/719641/941a8104-8616-4b15-9a88-25368b2fc80e">
