### PR TITLE
refactor: improve `mdx` syntax highlighting and add support for other languages in example

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,12 +6,30 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Theme (dev)",
+      "name": "Example App (dev)",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
         "${workspaceFolder}/example",
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "env": {
+        "VSCODE_EXPO_DEBUG": "vscode-expo*",
+        "VSCODE_EXPO_TELEMETRY_KEY": null,
+      },
+      "outFiles": [
+        "${workspaceFolder}/build/**"
+      ],
+      "preLaunchTask": "dev"
+    },
+    {
+      "name": "Example Languages (dev)",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "${workspaceFolder}/example-languages",
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "env": {

--- a/example-languages/example.java
+++ b/example-languages/example.java
@@ -1,0 +1,39 @@
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class SwitchExpression {
+    private Map<Integer, Position> positionMap = new HashMap<>();
+    private int                    randomNumber;
+    private Position               randomPosition;
+    @BeforeEach
+    public void setup() {
+        positionMap.put(1, GOALKEEPER);
+        positionMap.put(2, DEFENCE);
+        positionMap.put(3, MIDFIELDER);
+        positionMap.put(4, STRIKER);
+        randomNumber = ThreadLocalRandom.current().nextInt(1, 6);
+        randomPosition = Optional.ofNullable(positionMap.get(randomNumber)).orElse(BENCH);
+    }
+    @AfterEach
+    public void tearDown() {
+        positionMap.clear();
+    }
+    @RepeatedTest(5)
+    @Order(1)
+    public void oldSwitchExpressionTest() {
+        switch (randomPosition) {
+            case GOALKEEPER:
+                System.out.println("Goal Keeper");
+                break;
+            case DEFENCE:
+                System.out.println("Defence");
+                break;
+            case MIDFIELDER:
+                System.out.println("Midfielder");
+                break;
+            case STRIKER:
+                System.out.println("Striker");
+                break;
+            default:
+                System.out.println("Please select a footballer!");
+        }
+    }
+}

--- a/example-languages/example.kt
+++ b/example-languages/example.kt
@@ -1,0 +1,58 @@
+package com.example.expo.language
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class SettingsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        fragmentManager.beginTransaction()
+            .replace(android.R.id.content, SettingsFragment())
+            .commit()
+    }
+}
+
+private fun setUpPurchaseButtons(cipherNotInvalidated: Cipher, defaultCipher: Cipher) {
+    val purchaseButton = findViewById<Button>(R.id.purchase_button)
+    val purchaseButtonNotInvalidated = findViewById<Button>(R.id.purchase_button_not_invalidated)
+
+    if (BiometricManager.from(application).canAuthenticate() == BiometricManager.BIOMETRIC_SUCCESS) {
+        createKey(DEFAULT_KEY_NAME)
+        createKey(KEY_NAME_NOT_INVALIDATED, false)
+
+        purchaseButtonNotInvalidated.run {
+            isEnabled = true
+            setOnClickListener(PurchaseButtonClickListener(cipherNotInvalidated, KEY_NAME_NOT_INVALIDATED))
+        }
+        purchaseButton.run {
+            isEnabled = true
+            setOnClickListener(PurchaseButtonClickListener(defaultCipher, DEFAULT_KEY_NAME))
+        }
+    } else {
+        showToast(getString(R.string.setup_lock_screen))
+        purchaseButton.isEnabled = false
+        purchaseButtonNotInvalidated.isEnabled = false
+    }
+}
+
+private fun setupCiphers(): Pair<Cipher, Cipher> {
+    val defaultCipher: Cipher
+    val cipherNotInvalidated: Cipher
+    try {
+        val cipherString = "$KEY_ALGORITHM_AES/$BLOCK_MODE_CBC/$ENCRYPTION_PADDING_PKCS7"
+        defaultCipher = Cipher.getInstance(cipherString)
+        cipherNotInvalidated = Cipher.getInstance(cipherString)
+    } catch (e: Exception) {
+        when (e) {
+            is NoSuchAlgorithmException,
+            is NoSuchPaddingException ->
+                throw RuntimeException("Failed to get an instance of Cipher", e)
+            else -> throw e
+        }
+    }
+    return Pair(defaultCipher, cipherNotInvalidated)
+}
+
+companion object {
+    private const val ANDROID_KEY_STORE = "AndroidKeyStore"
+}

--- a/example-languages/example.md
+++ b/example-languages/example.md
@@ -1,0 +1,41 @@
+# Expo Dark
+
+This is the *Expo Dark* theme in **Visual Studio Code for the Web**!
+
+---
+
+**bold text** *italicized text* ~~strike through.~~
+
+> this is a block quote
+
+
+### Ordered list
+
+1. First item
+2. Second item
+3. Third item
+
+### Unordered list
+
+- First item
+- Second item
+- Third item
+
+### Fenced code
+
+```json
+{
+  "firstName": "John",
+  "lastName": "Smith",
+  "age": 25
+}
+```
+
+
+### Table
+
+| Syntax | Description |
+| ----------- | ----------- |
+| Header | Title |
+| Paragraph | Text |
+

--- a/example-languages/example.mdx
+++ b/example-languages/example.mdx
@@ -1,0 +1,46 @@
+import { ExpoLogo } from '@expo/styleguide';
+
+# Expo Dark
+
+This is the *Expo Dark* theme in **Visual Studio Code for the Web**!
+
+---
+
+**bold text** *italicized text* ~~strike through.~~
+
+> this is a block quote
+
+
+### Ordered list
+
+1. First item
+2. Second item
+3. Third item
+
+### Unordered list
+
+- First item
+- Second item
+- Third item
+
+### Fenced code
+
+```json
+{
+  "firstName": "John",
+  "lastName": "Smith",
+  "age": 25
+}
+```
+
+
+### Table
+
+| Syntax | Description |
+| ----------- | ----------- |
+| Header | Title |
+| Paragraph | Text |
+
+<Text theme="secondary" fontWeight={700} />
+
+<ExpoLogo />

--- a/example-languages/example.swift
+++ b/example-languages/example.swift
@@ -27,7 +27,6 @@ func collectCustomerProviders(_ customerProvider: @autoclosure @escaping () -> S
     customerProviders.append(customerProvider)
 }
 collectCustomerProviders(customersInLine.remove(at: 0))
-collectCustomerProviders(customersInLine.remove(at: 0))
 
 enum OnOffSwitch: Togglable {
     case off, on

--- a/example-languages/example.swift
+++ b/example-languages/example.swift
@@ -1,0 +1,57 @@
+func loadPicture(from server: Server, completion: (Picture) -> Void, onFailure: () -> Void) {
+    if let picture = download("photo.jpg", from: server) {
+        completion(picture)
+    } else {
+        onFailure()
+    }
+}
+
+class SomeOtherClass {
+    var x = 10
+    func doSomething() {
+        someFunctionWithEscapingClosure { [self] in x = 100 }
+        someFunctionWithNonescapingClosure { x = 200 }
+    }
+}
+
+struct SomeStruct {
+    var x = 10
+    mutating func doSomething() {
+        someFunctionWithNonescapingClosure { x = 200 }  // Ok
+        someFunctionWithEscapingClosure { x = 100 }     // Error
+    }
+}
+
+var customerProviders: [() -> String] = []
+func collectCustomerProviders(_ customerProvider: @autoclosure @escaping () -> String) {
+    customerProviders.append(customerProvider)
+}
+collectCustomerProviders(customersInLine.remove(at: 0))
+collectCustomerProviders(customersInLine.remove(at: 0))
+
+enum OnOffSwitch: Togglable {
+    case off, on
+    mutating func toggle() {
+        switch self {
+        case .off:
+            self = .on
+        case .on:
+            self = .off
+        }
+    }
+}
+var lightSwitch = OnOffSwitch.off
+lightSwitch.toggle()
+
+func swapTwoInts(_ a: inout Int, _ b: inout Int)
+func swapTwoValues<T>(_ a: inout T, _ b: inout T)
+
+extension Vector2D {
+    static prefix func +++ (vector: inout Vector2D) -> Vector2D {
+        vector += vector
+        return vector
+    }
+}
+
+var toBeDoubled = Vector2D(x: 1.0, y: 4.0)
+let afterDoubling = +++toBeDoubled

--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -151,12 +151,15 @@ export default makeTheme({
     'source.ignore': {},
 
     'source.java': {
+      'entity.name.function': palette.dark.blue11,
       'keyword.control.new': palette.dark.red10,
       'storage.modifier': palette.dark.orange11,
       'storage.modifier.extends': palette.dark.pink10,
       'storage.modifier.implements': palette.dark.pink10,
       'storage.type': palette.dark.green11,
       'storage.type.primitive': palette.dark.pink10,
+      'storage.type.generic': palette.dark.green11,
+      'punctuation.terminator': darkTheme.text.tertiary,
     },
 
     'source.js': {},
@@ -168,17 +171,35 @@ export default makeTheme({
     'source.kotlin': {
       'keyword.control.new': palette.dark.red10,
       'storage.modifier': palette.dark.orange11,
-      'storage.type': palette.dark.green11,
+      'variable.parameter.function': palette.dark.yellow11,
+      'entity.other.inherited-class': palette.dark.purple11,
+      'punctuation.seperator': darkTheme.text.tertiary,
     },
 
     'text.html.markdown': {
       'fenced_code.block.language': palette.dark.purple11,
-      'markup.bold': palette.dark.orange11,
+      'markup.bold': palette.dark.pink10,
+      'markup.italic': palette.dark.green11,
+      'markup.strikethrough': palette.dark.red10,
       'markup.inline.raw.string': palette.dark.yellow11,
       'markup.underline.link': palette.dark.blue11,
       'meta.paragraph': darkTheme.text.default,
-      'punctuation.definition.heading.markdown': palette.dark.red10,
+      'punctuation.definition.heading': palette.dark.blue10,
       'string.other.link.title': palette.dark.green11,
+      'meta.separator': darkTheme.text.tertiary,
+    },
+
+    'source.mdx': {
+      'meta.paragraph': darkTheme.text.default,
+      'punctuation.definition.heading': palette.dark.blue10,
+      'string.other.begin.code.fenced': darkTheme.text.tertiary,
+      'string.other.end.code.fenced': darkTheme.text.tertiary,
+      'variable.ordered.list': darkTheme.text.tertiary,
+      'variable.unordered.list': darkTheme.text.tertiary,
+      'markup.code': palette.dark.purple11,
+      'string.other.number': darkTheme.text.tertiary,
+      'meta.separator': darkTheme.text.tertiary,
+      'support.class.component': palette.dark.orange10,
     },
 
     'source.objc': {
@@ -206,15 +227,21 @@ export default makeTheme({
 
     'source.swift': {
       'entity.name.type': palette.dark.blue11,
+      'support.function.any-method': palette.dark.blue11,
       'keyword.control.new': palette.dark.red10,
       'meta.parameter-clause': palette.dark.green11,
-      'meta.function-call': palette.dark.blue11,
+      'meta.function-call': darkTheme.text.default,
+      'entity.name.function': palette.dark.blue11,
       'meta.definition.function.body': darkTheme.text.default,
       'meta.definition.type.body': darkTheme.text.default,
       'meta.inheritance-clause': palette.dark.orange11,
       'punctuation.definition.attribute': palette.dark.orange11,
       'storage.modifier': palette.dark.orange11,
       'support.type': palette.dark.green11,
+      'support.function': palette.dark.purple11,
+      'variable.parameter.function': palette.dark.yellow11,
+      'meta.function-result': palette.dark.green11,
+      'variable.language.generic-parameter': palette.dark.green11,
     },
 
     'source.ts': {

--- a/src/themes/expo-light.ts
+++ b/src/themes/expo-light.ts
@@ -1,4 +1,4 @@
-import { lightTheme, palette } from '@expo/styleguide-base';
+import { darkTheme, lightTheme, palette } from '@expo/styleguide-base';
 
 import { makeTheme } from '../blueprint';
 
@@ -157,12 +157,15 @@ export default makeTheme({
     'source.ignore': {},
 
     'source.java': {
+      'entity.name.function': palette.dark.blue11,
       'keyword.control.new': palette.light.red10,
       'storage.modifier': palette.light.orange10,
       'storage.modifier.extends': palette.light.pink10,
       'storage.modifier.implements': palette.light.pink10,
       'storage.type': palette.light.green11,
       'storage.type.primitive': palette.light.pink10,
+      'storage.type.generic': palette.light.green11,
+      'punctuation.terminator': lightTheme.text.tertiary,
     },
 
     'source.js': {},
@@ -174,17 +177,35 @@ export default makeTheme({
     'source.kotlin': {
       'keyword.control.new': palette.light.red10,
       'storage.modifier': palette.light.orange10,
-      'storage.type': palette.light.green11,
+      'variable.parameter.function': palette.light.yellow11,
+      'entity.other.inherited-class': palette.light.purple11,
+      'punctuation.seperator': lightTheme.text.tertiary,
     },
 
     'text.html.markdown': {
       'fenced_code.block.language': palette.light.purple11,
-      'markup.bold': palette.light.orange10,
-      'markup.inline.raw.string': '#C07F00',
+      'markup.bold': palette.light.pink10,
+      'markup.italic': palette.light.green11,
+      'markup.strikethrough': palette.light.red10,
+      'markup.inline.raw.string': palette.light.yellow11,
       'markup.underline.link': palette.light.blue11,
       'meta.paragraph': lightTheme.text.default,
-      'punctuation.definition.heading.markdown': palette.light.red10,
+      'punctuation.definition.heading.markdown': palette.light.blue10,
       'string.other.link.title': palette.light.green11,
+      'meta.separator': lightTheme.text.tertiary,
+    },
+
+    'source.mdx': {
+      'meta.paragraph': lightTheme.text.default,
+      'punctuation.definition.heading': palette.light.blue10,
+      'string.other.begin.code.fenced': lightTheme.text.tertiary,
+      'string.other.end.code.fenced': lightTheme.text.tertiary,
+      'variable.ordered.list': lightTheme.text.tertiary,
+      'variable.unordered.list': lightTheme.text.tertiary,
+      'markup.code': palette.light.purple11,
+      'string.other.number': lightTheme.text.tertiary,
+      'meta.separator': lightTheme.text.tertiary,
+      'support.class.component': palette.light.orange10,
     },
 
     'source.objc': {
@@ -212,15 +233,19 @@ export default makeTheme({
 
     'source.swift': {
       'entity.name.type': palette.light.blue11,
+      'support.function.any-method': palette.light.blue11,
       'keyword.control.new': palette.light.red10,
       'meta.parameter-clause': palette.light.green11,
-      'meta.function-call': palette.light.blue11,
+      'meta.function-call': lightTheme.text.default,
+      'entity.name.function': palette.light.blue11,
       'meta.definition.function.body': lightTheme.text.default,
       'meta.definition.type.body': lightTheme.text.default,
       'meta.inheritance-clause': palette.light.orange10,
       'punctuation.definition.attribute': palette.light.orange10,
       'storage.modifier': palette.light.orange10,
       'support.type': palette.light.green11,
+      'support.function': palette.light.purple11,
+      'variable.parameter.function': palette.light.yellow11,
     },
 
     'source.ts': {

--- a/src/themes/expo-light.ts
+++ b/src/themes/expo-light.ts
@@ -1,4 +1,4 @@
-import { darkTheme, lightTheme, palette } from '@expo/styleguide-base';
+import { lightTheme, palette } from '@expo/styleguide-base';
 
 import { makeTheme } from '../blueprint';
 


### PR DESCRIPTION
# Changelog

* feat: better MDX syntax highlight
* fix: tweaks for Java, Kotlin, Markdown and Swift syntax highlight
* chore: add languages example files and test bench script

# Preview

<img width="380" align="left" alt="Screenshot 2023-07-26 at 16 17 42" src="https://github.com/expo/vscode-expo-theme/assets/719641/fd24f844-bf97-4309-8b61-b9175fbc4a6d">
<img width="380" alt="Screenshot 2023-07-26 at 16 17 25" src="https://github.com/expo/vscode-expo-theme/assets/719641/8739c884-10cb-4b0c-8815-0814a0523943">
<img width="380" align="left"  alt="Screenshot 2023-07-26 at 16 18 07" src="https://github.com/expo/vscode-expo-theme/assets/719641/7c3a181b-ff60-485c-8f6c-db0dc0f09dcd">
<img width="380" alt="Screenshot 2023-07-26 at 16 17 55" src="https://github.com/expo/vscode-expo-theme/assets/719641/49c476c1-bb6c-47e5-b19c-9d7fef01ff69">

