### PR TITLE
fix: tweaks for Java, Kotlin, Markdown and Swift syntax highlight

### DIFF
--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -151,12 +151,15 @@ export default makeTheme({
     'source.ignore': {},
 
     'source.java': {
+      'entity.name.function': palette.dark.blue11,
       'keyword.control.new': palette.dark.red10,
       'storage.modifier': palette.dark.orange11,
       'storage.modifier.extends': palette.dark.pink10,
       'storage.modifier.implements': palette.dark.pink10,
       'storage.type': palette.dark.green11,
       'storage.type.primitive': palette.dark.pink10,
+      'storage.type.generic': palette.dark.green11,
+      'punctuation.terminator': darkTheme.text.tertiary,
     },
 
     'source.js': {},
@@ -168,17 +171,22 @@ export default makeTheme({
     'source.kotlin': {
       'keyword.control.new': palette.dark.red10,
       'storage.modifier': palette.dark.orange11,
-      'storage.type': palette.dark.green11,
+      'variable.parameter.function': palette.dark.yellow11,
+      'entity.other.inherited-class': palette.dark.purple11,
+      'punctuation.seperator': darkTheme.text.tertiary,
     },
 
     'text.html.markdown': {
       'fenced_code.block.language': palette.dark.purple11,
-      'markup.bold': palette.dark.orange11,
+      'markup.bold': palette.dark.pink10,
+      'markup.italic': palette.dark.green11,
+      'markup.strikethrough': palette.dark.red10,
       'markup.inline.raw.string': palette.dark.yellow11,
       'markup.underline.link': palette.dark.blue11,
       'meta.paragraph': darkTheme.text.default,
-      'punctuation.definition.heading.markdown': palette.dark.red10,
+      'punctuation.definition.heading': palette.dark.blue10,
       'string.other.link.title': palette.dark.green11,
+      'meta.separator': darkTheme.text.tertiary,
     },
 
     'source.objc': {
@@ -206,15 +214,21 @@ export default makeTheme({
 
     'source.swift': {
       'entity.name.type': palette.dark.blue11,
+      'support.function.any-method': palette.dark.blue11,
       'keyword.control.new': palette.dark.red10,
       'meta.parameter-clause': palette.dark.green11,
-      'meta.function-call': palette.dark.blue11,
+      'meta.function-call': darkTheme.text.default,
+      'entity.name.function': palette.dark.blue11,
       'meta.definition.function.body': darkTheme.text.default,
       'meta.definition.type.body': darkTheme.text.default,
       'meta.inheritance-clause': palette.dark.orange11,
       'punctuation.definition.attribute': palette.dark.orange11,
       'storage.modifier': palette.dark.orange11,
       'support.type': palette.dark.green11,
+      'support.function': palette.dark.purple11,
+      'variable.parameter.function': palette.dark.yellow11,
+      'meta.function-result': palette.dark.green11,
+      'variable.language.generic-parameter': palette.dark.green11,
     },
 
     'source.ts': {

--- a/src/themes/expo-light.ts
+++ b/src/themes/expo-light.ts
@@ -157,12 +157,15 @@ export default makeTheme({
     'source.ignore': {},
 
     'source.java': {
+      'entity.name.function': palette.dark.blue11,
       'keyword.control.new': palette.light.red10,
       'storage.modifier': palette.light.orange10,
       'storage.modifier.extends': palette.light.pink10,
       'storage.modifier.implements': palette.light.pink10,
       'storage.type': palette.light.green11,
       'storage.type.primitive': palette.light.pink10,
+      'storage.type.generic': palette.light.green11,
+      'punctuation.terminator': lightTheme.text.tertiary,
     },
 
     'source.js': {},
@@ -174,17 +177,22 @@ export default makeTheme({
     'source.kotlin': {
       'keyword.control.new': palette.light.red10,
       'storage.modifier': palette.light.orange10,
-      'storage.type': palette.light.green11,
+      'variable.parameter.function': palette.light.yellow11,
+      'entity.other.inherited-class': palette.light.purple11,
+      'punctuation.seperator': lightTheme.text.tertiary,
     },
 
     'text.html.markdown': {
       'fenced_code.block.language': palette.light.purple11,
-      'markup.bold': palette.light.orange10,
-      'markup.inline.raw.string': '#C07F00',
+      'markup.bold': palette.light.pink10,
+      'markup.italic': palette.light.green11,
+      'markup.strikethrough': palette.light.red10,
+      'markup.inline.raw.string': palette.light.yellow11,
       'markup.underline.link': palette.light.blue11,
       'meta.paragraph': lightTheme.text.default,
-      'punctuation.definition.heading.markdown': palette.light.red10,
+      'punctuation.definition.heading.markdown': palette.light.blue10,
       'string.other.link.title': palette.light.green11,
+      'meta.separator': lightTheme.text.tertiary,
     },
 
     'source.objc': {
@@ -212,15 +220,19 @@ export default makeTheme({
 
     'source.swift': {
       'entity.name.type': palette.light.blue11,
+      'support.function.any-method': palette.light.blue11,
       'keyword.control.new': palette.light.red10,
       'meta.parameter-clause': palette.light.green11,
-      'meta.function-call': palette.light.blue11,
+      'meta.function-call': lightTheme.text.default,
+      'entity.name.function': palette.light.blue11,
       'meta.definition.function.body': lightTheme.text.default,
       'meta.definition.type.body': lightTheme.text.default,
       'meta.inheritance-clause': palette.light.orange10,
       'punctuation.definition.attribute': palette.light.orange10,
       'storage.modifier': palette.light.orange10,
       'support.type': palette.light.green11,
+      'support.function': palette.light.purple11,
+      'variable.parameter.function': palette.light.yellow11,
     },
 
     'source.ts': {


### PR DESCRIPTION
Fixes from #11