### PR TITLE
fix: tweaks for Dart files syntax highlight

### DIFF
--- a/example-languages/example.dart
+++ b/example-languages/example.dart
@@ -1,0 +1,37 @@
+var antennaDiameter = 3.7;
+var flybyObjects = ['Jupiter', 'Saturn', 'Uranus', 'Neptune'];
+var image = {
+  'tags': ['saturn'],
+  'url': '//path/to/saturn.jpg'
+};
+
+class Spacecraft {
+  String name;
+  DateTime? launchDate;
+  @Deprecated('Use launchDate instead')
+  int? get launchYear => launchDate?.year;
+
+  Spacecraft(this.name, this.launchDate) {
+    // Initialization code goes here.
+  }
+
+  Spacecraft.unlaunched(String name) : this(name, null);
+
+  void describe() {
+    print('Spacecraft: $name');
+    var launchDate = this.launchDate;
+    if (launchDate != null) {
+      int years = DateTime.now().difference(launchDate).inDays ~/ 365;
+      print('Launched: $launchYear ($years years ago)');
+    } else {
+      print('Unlaunched');
+    }
+  }
+}
+
+Stream<String> report(Spacecraft craft, Iterable<String> objects) async* {
+  for (final object in objects) {
+    await Future.delayed(oneSecond);
+    yield '${craft.name} flies by $object';
+  }
+}

--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -261,11 +261,15 @@ export default makeTheme({
     'source.yaml': {},
 
     'source.dart': {
-      'support.class.dart': palette.dark.orange10,
       'entity.name.function': palette.dark.blue11,
+      'keyword.declaration': palette.dark.pink10,
+      punctuation: darkTheme.text.tertiary,
+      'other.source': darkTheme.text.tertiary,
       'string.interpolated': palette.dark.yellow11,
       'string.quoted': palette.dark.yellow11,
       'string.template': palette.dark.yellow11,
+      'support.class': palette.dark.orange10,
+      'variable.parameter': palette.dark.red10,
     },
   },
 });

--- a/src/themes/expo-light.ts
+++ b/src/themes/expo-light.ts
@@ -265,11 +265,15 @@ export default makeTheme({
     'source.yaml': {},
 
     'source.dart': {
-      'support.class.dart': palette.light.orange10,
       'entity.name.function': palette.light.blue11,
+      'keyword.declaration': palette.light.pink10,
+      punctuation: lightTheme.text.tertiary,
+      'other.source': lightTheme.text.tertiary,
       'string.interpolated': '#C07F00',
       'string.quoted': '#C07F00',
       'string.template': '#C07F00',
+      'support.class.dart': palette.light.orange10,
+      'variable.parameter': palette.light.red10,
     },
   },
 });


### PR DESCRIPTION
# Why & how

Use tertiary text color for punctuations and unclassified tokens (i.e. generic type wrappers), highlight language keywords and interpolated variables, add Dart example file.

# Preview

<img width="710" alt="Screenshot 2023-07-30 at 22 33 02" src="https://github.com/expo/vscode-expo-theme/assets/719641/72b75ad0-f18f-4249-8e87-cba670ae0caa">
