### PR TITLE
feat: improve C# files syntax highlight

### DIFF
--- a/example-languages/example.cs
+++ b/example-languages/example.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using Game.Systems;
+using Game.Constants;
+using Game.Data;
+using Game.UI;
+using Game.Utils;
+using ExampleMod.Systems;
+
+namespace ExampleMod.UI {
+    public sealed class ExampleOverlayUI : IUIDataProvider {
+        private readonly ExampleModSys sys;
+        private readonly GameState S;
+
+        private readonly HashSet<string> foo = new();
+
+        public ExampleOverlayUI(ExampleModSys sys) {
+            this.sys = sys;
+            S = sys.S;
+        }
+
+        // This doesn't belong to an entity, so let's return a null
+        public Entity Entity => null;
+        private UDB header;
+
+        private void DoSomething() {
+            sys.SomeVariable++;
+            header.NeedsListRebuild = true;
+        }
+
+        private void OnButtonClick() {
+            UIPopupWidget.Spawn(IconId.CWarning, "some.popup".T(),
+                "Popups should be used extremely sparingly, since nobody reads this. Also, if you put the text in like this, it will be impossible to translate, use \"some.text\".T() instead.");
+        }
+
+        private void HideOverlay() {
+            S.Sig.HideTargetOverlay.Send(sys.Id);
+        }
+
+        public string GetName() {
+            return sys.Id;
+        }
+
+        public UDB GetUIBlock() {
+            return null;
+        }
+
+        public void GetUIDetails(List<UDB> res) {
+            header ??= UDB.Create(this, UDBT.DTextRBHeader, IconId.WList,
+                "example.system".T()).AsHeader().WithRBFunction(HideOverlay);
+            res.Add(header);
+
+            res.Add(UDB.Create(this, UDBT.IText, IconId.CInfo, "some.info".T())
+                .WithIconClickFunction(DoSomething)
+                .WithText(Units.XNum(sys.SomeVariable)));
+
+            res.Add(UDB.Create(this, UDBT.ITextBtn, IconId.CInfo, "other.info".T())
+                .WithTooltip("tooltips.are.great".T())
+                .WithText2(T.Execute)
+                .WithClickFunction(OnButtonClick));
+        }
+    }
+}

--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -276,6 +276,13 @@ export default makeTheme({
       'variable.parameter': palette.dark.red10,
     },
 
+    'source.cs': {
+      'keyword.type': palette.dark.orange10,
+      'keyword.type.void': palette.dark.pink10,
+      'entity.name.function': palette.dark.blue11,
+      'variable.other.object.property': palette.dark.purple11,
+    },
+
     'source.diff': {
       'meta.diff.header': palette.dark.blue11,
       'meta.diff.header.from-file': {

--- a/src/themes/expo-light.ts
+++ b/src/themes/expo-light.ts
@@ -279,6 +279,13 @@ export default makeTheme({
       'variable.parameter': palette.light.red10,
     },
 
+    'source.cs': {
+      'keyword.type.string': palette.light.orange10,
+      'keyword.type.void': palette.light.pink10,
+      'entity.name.function': palette.light.blue11,
+      'variable.other.object.property': palette.light.purple11,
+    },
+
     'source.diff': {
       'meta.diff.header': palette.light.blue11,
       'meta.diff.header.from-file': {


### PR DESCRIPTION
# Why

Improve the C# files syntax highlight by adding custom overwrites, add `cs` file to the example.

# Preview

<img width="616" alt="Screenshot 2023-10-07 at 10 05 30" src="https://github.com/expo/vscode-expo-theme/assets/719641/203dbf36-e910-4b77-9252-399bc054ed4d">
