### PR TITLE
feat: improve GDScript files syntax highlight

### DIFF
--- a/example-languages/example.gd
+++ b/example-languages/example.gd
@@ -1,0 +1,72 @@
+# A file is a class!
+
+# Inheritance
+
+extends BaseClass
+
+# (optional) class definition with a custom icon
+
+class_name MyClass, "res://path/to/optional/icon.svg"
+
+# Member Variables
+
+var a = 5
+var s = "Hello"
+var arr = [1, 2, 3]
+var dict = {"key": "value", 2:3}
+var typed_var: int
+var inferred_type := "String"
+
+# Constants
+
+const ANSWER = 42
+const THE_NAME = "Charly"
+
+# Enums
+
+enum {UNIT_NEUTRAL, UNIT_ENEMY, UNIT_ALLY}
+enum Named {THING_1, THING_2, ANOTHER_THING = -1}
+
+# Built-in Vector Types
+
+var v2 = Vector2(1, 2)
+var v3 = Vector3(1, 2, 3)
+
+# Function
+
+func some_function(param1, param2):
+    var local_var = 5
+
+    if param1 < local_var:
+        print(param1)
+    elif param2 > 5:
+        print(param2)
+    else:
+        print("Fail!")
+
+    for i in range(20):
+        print(i)
+
+    while param2 != 0:
+        param2 -= 1
+
+    var local_var2 = param1 + 3
+    return local_var2
+
+# Functions override functions with the same name on the base/parent class.
+# If you still want to call them, use '.' (like 'super' in other languages).
+
+func something(p1, p2):
+    .something(p1, p2)
+
+# Inner Class
+
+class Something:
+    var a = 10
+
+# Constructor
+
+func _init():
+    print("Constructed!")
+    var lv = Something.new()
+    print(lv.a)

--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -264,6 +264,17 @@ export default makeTheme({
 
     'source.yaml': {},
 
+    'source.gdscript': {
+      'constant.language': palette.dark.orange11,
+      'entity.name.function': palette.dark.blue11,
+      'entity.name.type.class': palette.dark.red10,
+      'entity.other.inherited-class': palette.dark.red10,
+      'keyword.language': palette.dark.pink10,
+      'keyword.control': palette.dark.pink10,
+      'support.function': palette.dark.blue11,
+      'variable.parameter.function': palette.dark.green11,
+    },
+
     'source.dart': {
       'entity.name.function': palette.dark.blue11,
       'keyword.declaration': palette.dark.pink10,

--- a/src/themes/expo-light.ts
+++ b/src/themes/expo-light.ts
@@ -267,6 +267,17 @@ export default makeTheme({
 
     'source.yaml': {},
 
+    'source.gdscript': {
+      'constant.language': palette.light.orange11,
+      'entity.name.function': palette.light.blue11,
+      'entity.name.type.class': palette.light.red10,
+      'entity.other.inherited-class': palette.light.red10,
+      'keyword.language': palette.light.pink10,
+      'keyword.control': palette.light.pink10,
+      'support.function': palette.light.blue11,
+      'variable.parameter.function': palette.light.green11,
+    },
+
     'source.dart': {
       'entity.name.function': palette.light.blue11,
       'keyword.declaration': palette.light.pink10,


### PR DESCRIPTION
# Why

Improve the GDScript (Godot) files syntax highlight by adding custom overwrites, add `gd` file to the example.

# Preview

<img width="616" alt="Screenshot 2023-10-07 at 10 23 18" src="https://github.com/expo/vscode-expo-theme/assets/719641/f091945f-1f91-4aa5-b59e-74a882ee2e0e">
