### PR TITLE
fix: improve JS(X)/TS(X) syntax highlight

### DIFF
--- a/example-languages/example.js
+++ b/example-languages/example.js
@@ -1,0 +1,102 @@
+// This test file has been based on:
+// https://github.com/sharkdp/bat/blob/master/tests/syntax-tests/source/JavaScript/test.js
+
+/**
+ * #########
+ * Multiline
+ * comment
+ * #########
+ */
+
+let test;
+for (let i = 0; i < 10; i++) {
+  if (test) continue;
+  else test += 1; // random things
+}
+
+while (test < 100 && typeof test === 'number') {
+  test = test > 30 ? test + 5 : test + 1;
+}
+
+function weatherSays(when = Date.now()) {
+  return 'rain';
+}
+
+const thereAreClouds = true;
+const cloudsCount = 20;
+const list = ['thing', 'thing2', `foo`, ['bar']];
+
+Array.isArray(list);
+
+switch (weatherSays(Date.now())) {
+  case 'rain':
+    break;
+  case 'sun':
+  default:
+    break;
+}
+
+let rain = false;
+if ((thereAreClouds && cloudsCount >= 20) || weatherSays() === 'rain') {
+  rain = false;
+} else if (thereAreClouds && weatherSays() === 'rain') {
+  rain = true;
+} else {
+  rain = !!cloudsCount;
+}
+
+console.warn(rain, ...list);
+
+class Forecast {
+  constructor(where, isGonnaRainA = true, ...randomArgs) {
+    this.station = {
+      location: [where.x, where.y, where.z],
+      surroundings: {
+        zoneA: {
+          location: [1, 2, 3],
+          isGonnaRain: isGonnaRainA,
+        },
+      },
+    };
+  }
+
+  async getLocalPrevisions() {
+    const rainZones = [this.station.surroundings.zoneA.isGonnaRain];
+    return (await rainZones.filter((z) => !!z).length) > rainZones.length / 2;
+  }
+
+  communicatePrevisions(isGonnaRain = undefined) {
+    if (isGonnaRain) console.log('Take the umbrella.');
+  }
+
+  destroy() {
+    delete this.station;
+  }
+
+  static startHiring() {
+    console.log("We're looking for weather presenters.");
+  }
+
+  *generateRainInZoneC(clouds = [1, 2, 3]) {
+    this.station.surroundings.zoneC.isGonnaRain = true;
+    const makeRain = () => {
+      return 'raining!';
+    };
+
+    yield clouds;
+    do {
+      console.log(makeRain());
+      yield clouds.pop();
+    } while (clouds.length >= 1);
+  }
+}
+
+Forecast.startHiring();
+const forecasting = new Forecast([3, 3, 3]);
+(async () => {
+  const raining = forecasting.generateRainInZoneC();
+  raining.next();
+  forecasting.communicatePrevisions(await forecasting.getLocalPrevisions());
+  raining.return('stop!');
+  forecasting.destroy();
+})();

--- a/example-languages/example.ts
+++ b/example-languages/example.ts
@@ -1,0 +1,120 @@
+// This test file has been based on:
+// https://github.com/sharkdp/bat/blob/master/tests/syntax-tests/source/TypeScript/example.ts
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/*
+ * Multiline comments
+ * Multiline comments
+ */
+
+const letNumber = 10;
+const constNumber = 20;
+
+const bool: boolean = true;
+const array: number[] = [1, 2, 3];
+const pair: [string, number] = ['hello', 10];
+const map: Map<string, boolean> = new Map();
+
+for (let i = 0; i < array.length; i += 1) {
+  console.log(array[i]);
+}
+
+if (bool) {
+  console.log('True');
+} else {
+  console.group('False', {});
+}
+
+const str: string = 'Jake';
+const templateStr: string = `Hello, ${str}!`;
+
+interface SquareConfig {
+  label: string;
+  color?: string;
+  width?: number;
+  [propName: string]: any;
+}
+
+interface SearchFunc {
+  (source: string, subString: string): boolean;
+}
+
+enum Color {
+  Red,
+  Green,
+}
+
+type Easing = 'ease-in' | 'ease-out' | 'ease-in-out';
+
+type AnyProps = {
+  one: boolean;
+  2: '2' | Date;
+  ['thr-ee']: Pick<SquareConfig, 'label' | 'color'>;
+  onPress: (one: any, { nested }: Record<string, boolean>) => Promise<void>;
+};
+
+type GenericNumber<T> = {
+  zeroValue: T;
+  add: (x: T, y: T) => T;
+};
+
+class Greeter {
+  private readonly greeting: string;
+
+  constructor(message: string) {
+    this.greeting = message;
+  }
+
+  greet() {
+    return 'Hello, ' + this.greeting;
+  }
+}
+
+const greeter = new Greeter('world');
+
+class Animal {
+  move(distanceInMeters: number = 0) {
+    console.log(`Animal moved ${distanceInMeters}m.`);
+  }
+}
+
+class Dog extends Animal {
+  bark() {
+    console.log('Woof! Woof!');
+  }
+}
+
+const dog = new Dog();
+dog.bark();
+dog.move(10);
+dog.bark();
+
+class Point {
+  x!: number;
+  y!: number;
+}
+
+interface Point3d extends Point {
+  z: number;
+}
+
+const point3d: Point3d = { x: 1, y: 2, z: 3 };
+
+function add(x: number, y: number) {
+  return x + y;
+}
+
+const myAdd = (x: number, y: number) => {
+  return x + y;
+};
+
+(function () {
+  console.log('IIFE');
+})();
+
+function identity<T>(arg: T): T {
+  return arg;
+}
+
+const myIdentity: <T>(arg: T) => T = identity;

--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -121,6 +121,8 @@ export default makeTheme({
     'meta.brace': darkTheme.text.quaternary,
     'meta.definition.variable': darkTheme.text.default,
     'meta.definition.function': palette.dark.blue11,
+    'meta.definition.method': palette.dark.blue11,
+    'meta.definition.property': palette.dark.blue11,
     'meta.function-call': palette.dark.purple11,
     'meta.import': darkTheme.text.default,
     'meta.object-literal.key': darkTheme.text.default,

--- a/src/themes/expo-light.ts
+++ b/src/themes/expo-light.ts
@@ -127,6 +127,8 @@ export default makeTheme({
     'meta.brace': lightTheme.text.quaternary,
     'meta.definition.variable': lightTheme.text.default,
     'meta.definition.function': palette.light.blue11,
+    'meta.definition.method': palette.light.blue11,
+    'meta.definition.property': palette.light.blue11,
     'meta.function-call': palette.light.purple11,
     'meta.import': lightTheme.text.default,
     'meta.object-literal.key': lightTheme.text.default,
@@ -263,6 +265,7 @@ export default makeTheme({
     'source.ts': {
       'punctuation.definition.block.tag.jsdoc': palette.light.orange10,
       'storage.type.class.jsdoc': palette.light.orange10,
+      'meta.definition.property': palette.light.blue11,
     },
 
     'source.tsx': {


### PR DESCRIPTION
# Why

Cedric has reported some inconsistency in TS(X) files highlight.

# How

Update the general theme definition to include two more token keys.

To make sure that the JS/TS highlight looks fine I have added two new test cases. I have also verified that those new global token colors do not degrade highlight of other languages.

# Preview

![Screenshot 2024-02-23 at 12 23 44](https://github.com/expo/vscode-expo-theme/assets/719641/c070d749-c6a9-4c3b-90e0-4bc05ad8e69c)
