### PR TITLE
fix: improve Rust and Zig syntax highlight

### DIFF
--- a/example-languages/example.rs
+++ b/example-languages/example.rs
@@ -1,0 +1,107 @@
+use gpui::{
+    App, Application, Context, Global, Menu, MenuItem, SharedString, SystemMenuType, Window,
+    WindowOptions, actions, div, prelude::*, rgb,
+};
+
+struct SetMenus;
+
+impl Render for SetMenus {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .bg(rgb(0x2e7d32))
+            .size_full()
+            .justify_center()
+            .items_center()
+            .text_xl()
+            .text_color(rgb(0xffffff))
+            .child("Set Menus Example")
+    }
+}
+
+fn main() {
+    Application::new().run(|cx: &mut App| {
+        cx.set_global(AppState::new());
+
+        // Bring the menu bar to the foreground (so you can see the menu bar)
+        cx.activate(true);
+        // Register the `quit` function so it can be referenced by the `MenuItem::action` in the menu bar
+        cx.on_action(quit);
+        cx.on_action(toggle_check);
+        // Add menu items
+        set_app_menus(cx);
+        cx.open_window(WindowOptions::default(), |_, cx| cx.new(|_| SetMenus {}))
+            .unwrap();
+    });
+}
+
+#[derive(PartialEq)]
+enum ViewMode {
+    List,
+    Grid,
+}
+
+impl ViewMode {
+    fn toggle(&mut self) {
+        *self = match self {
+            ViewMode::List => ViewMode::Grid,
+            ViewMode::Grid => ViewMode::List,
+        }
+    }
+}
+
+impl Into<SharedString> for ViewMode {
+    fn into(self) -> SharedString {
+        match self {
+            ViewMode::List => "List",
+            ViewMode::Grid => "Grid",
+        }
+        .into()
+    }
+}
+
+struct AppState {
+    view_mode: ViewMode,
+}
+
+impl AppState {
+    fn new() -> Self {
+        Self {
+            view_mode: ViewMode::List,
+        }
+    }
+}
+
+impl Global for AppState {}
+
+fn set_app_menus(cx: &mut App) {
+    let app_state = cx.global::<AppState>();
+    cx.set_menus(vec![Menu {
+        name: "set_menus".into(),
+        items: vec![
+            MenuItem::os_submenu("Services", SystemMenuType::Services),
+            MenuItem::separator(),
+            MenuItem::action(ViewMode::List, ToggleCheck)
+                .checked(app_state.view_mode == ViewMode::List),
+            MenuItem::action(ViewMode::Grid, ToggleCheck)
+                .checked(app_state.view_mode == ViewMode::Grid),
+            MenuItem::separator(),
+            MenuItem::action("Quit", Quit),
+        ],
+    }]);
+}
+
+// Associate actions using the `actions!` macro (or `Action` derive macro)
+actions!(set_menus, [Quit, ToggleCheck]);
+
+// Define the quit function that is registered with the App
+fn quit(_: &Quit, cx: &mut App) {
+    println!("Gracefully quitting the application...");
+    cx.quit();
+}
+
+fn toggle_check(_: &ToggleCheck, cx: &mut App) {
+    let app_state = cx.global_mut::<AppState>();
+    app_state.view_mode.toggle();
+    set_app_menus(cx);
+}

--- a/example-languages/example.zig
+++ b/example-languages/example.zig
@@ -1,0 +1,90 @@
+// compile with `zig build-exe zig-curl-test.zig --library curl --library c $(pkg-config --cflags libcurl)`
+const std = @import("std");
+const cURL = @cImport({
+    @cInclude("curl/curl.h");
+});
+
+pub fn main() !void {
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+    defer arena_state.deinit();
+
+    const allocator = arena_state.allocator();
+
+    // global curl init, or fail
+    if (cURL.curl_global_init(cURL.CURL_GLOBAL_ALL) != cURL.CURLE_OK)
+        return error.CURLGlobalInitFailed;
+    defer cURL.curl_global_cleanup();
+
+    // curl easy handle init, or fail
+    const handle = cURL.curl_easy_init() orelse return error.CURLHandleInitFailed;
+    defer cURL.curl_easy_cleanup(handle);
+
+    var response_buffer = std.ArrayList(u8).init(allocator);
+
+    // superfluous when using an arena allocator, but
+    // important if the allocator implementation changes
+    defer response_buffer.deinit();
+
+    // setup curl options
+    if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_URL, "https://ziglang.org") != cURL.CURLE_OK)
+        return error.CouldNotSetURL;
+
+    // set write function callbacks
+    if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_WRITEFUNCTION, writeToArrayListCallback) != cURL.CURLE_OK)
+        return error.CouldNotSetWriteCallback;
+    if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_WRITEDATA, &response_buffer) != cURL.CURLE_OK)
+        return error.CouldNotSetWriteCallback;
+
+    // perform
+    if (cURL.curl_easy_perform(handle) != cURL.CURLE_OK)
+        return error.FailedToPerformRequest;
+
+    std.log.info("Got response of {d} bytes", .{response_buffer.items.len});
+    std.debug.print("{s}\n", .{response_buffer.items});
+}
+
+fn writeToArrayListCallback(data: *anyopaque, size: c_uint, nmemb: c_uint, user_data: *anyopaque) callconv(.C) c_uint {
+    var buffer: *std.ArrayList(u8) = @alignCast(@ptrCast(user_data));
+    var typed_data: [*]u8 = @ptrCast(data);
+    buffer.appendSlice(typed_data[0 .. nmemb * size]) catch return 0;
+    return nmemb * size;
+}
+
+pub fn Queue(comptime Child: type) type {
+    return struct {
+        const Self = @This();
+        const Node = struct {
+            data: Child,
+            next: ?*Node,
+        };
+        gpa: std.mem.Allocator,
+        start: ?*Node,
+        end: ?*Node,
+
+        pub fn init(gpa: std.mem.Allocator) Self {
+            return Self{
+                .gpa = gpa,
+                .start = null,
+                .end = null,
+            };
+        }
+        pub fn enqueue(self: *Self, value: Child) !void {
+            const node = try self.gpa.create(Node);
+            node.* = .{ .data = value, .next = null };
+            if (self.end) |end| end.next = node //
+            else self.start = node;
+            self.end = node;
+        }
+        pub fn dequeue(self: *Self) ?Child {
+            const start = self.start orelse return null;
+            defer self.gpa.destroy(start);
+            if (start.next) |next|
+                self.start = next
+            else {
+                self.start = null;
+                self.end = null;
+            }
+            return start.data;
+        }
+    };
+}

--- a/src/themes/expo-dark.ts
+++ b/src/themes/expo-dark.ts
@@ -297,7 +297,10 @@ export default makeTheme({
       'string.quoted': palette.dark.yellow11,
       'string.template': palette.dark.yellow11,
       'support.class': palette.dark.orange9,
-      'variable.parameter': palette.dark.red9,
+      'variable.parameter': palette.dark.orange9,
+      'storage.modifier': palette.dark.pink10,
+      'storage.type.annotation': palette.dark.red9,
+      'meta.embedded.expression': palette.dark.orange9,
     },
 
     'source.cs': {
@@ -305,6 +308,7 @@ export default makeTheme({
       'keyword.type.void': palette.dark.pink10,
       'entity.name.function': palette.dark.blue10,
       'variable.other.object.property': palette.dark.purple10,
+      punctuation: darkTheme.text.tertiary,
     },
 
     'source.diff': {
@@ -331,6 +335,26 @@ export default makeTheme({
       'punctuation.definition.inserted.diff': palette.dark.green7,
       'punctuation.definition.deleted.diff': palette.dark.red7,
       'punctuation.definition.range.diff': palette.dark.purple8,
+    },
+
+    'source.rust': {
+      'entity.name.function': palette.dark.blue10,
+      'keyword.control.flow': palette.dark.pink10,
+      'entity.name.namespace': palette.dark.orange10,
+      'meta.attribute.rust': palette.dark.red9,
+      punctuation: darkTheme.text.tertiary,
+    },
+
+    'source.zig': {
+      'entity.name.function': palette.dark.blue10,
+      'keyword.control.flow': palette.dark.pink10,
+      'keyword.default': palette.dark.pink10,
+      'keyword.structure': palette.dark.pink10,
+      'keyword.storage': palette.dark.purple10,
+      'keyword.type': palette.dark.purple10,
+      'keyword.type.c': palette.dark.green11,
+      'support.function.builtin.zig': palette.dark.orange10,
+      punctuation: darkTheme.text.tertiary,
     },
   },
 });

--- a/src/themes/expo-light.ts
+++ b/src/themes/expo-light.ts
@@ -298,11 +298,14 @@ export default makeTheme({
       'keyword.declaration': palette.light.pink10,
       punctuation: lightTheme.text.tertiary,
       'other.source': lightTheme.text.tertiary,
-      'string.interpolated': '#C07F00',
-      'string.quoted': '#C07F00',
-      'string.template': '#C07F00',
+      'string.interpolated': palette.light.yellow11,
+      'string.quoted': palette.light.yellow11,
+      'string.template': palette.light.yellow11,
       'support.class.dart': palette.light.orange9,
-      'variable.parameter': palette.light.red10,
+      'variable.parameter': palette.light.orange9,
+      'storage.modifier': palette.light.pink10,
+      'storage.type.annotation': palette.light.red10,
+      'meta.embedded.expression': palette.light.orange9,
     },
 
     'source.cs': {
@@ -310,6 +313,7 @@ export default makeTheme({
       'keyword.type.void': palette.light.pink10,
       'entity.name.function': palette.light.blue10,
       'variable.other.object.property': palette.light.purple11,
+      punctuation: lightTheme.text.tertiary,
     },
 
     'source.diff': {
@@ -336,6 +340,26 @@ export default makeTheme({
       'punctuation.definition.inserted.diff': palette.light.green8,
       'punctuation.definition.deleted.diff': palette.light.red8,
       'punctuation.definition.range.diff': palette.light.purple8,
+    },
+
+    'source.rust': {
+      'entity.name.function': palette.light.blue10,
+      'keyword.control.flow': palette.light.pink10,
+      'entity.name.namespace': palette.light.orange9,
+      'meta.attribute.rust': palette.light.red10,
+      punctuation: lightTheme.text.tertiary,
+    },
+
+    'source.zig': {
+      'entity.name.function': palette.light.blue10,
+      'keyword.control.flow': palette.light.pink10,
+      'keyword.default': palette.light.pink10,
+      'keyword.structure': palette.light.pink10,
+      'keyword.storage': palette.light.purple11,
+      'keyword.type': palette.light.purple11,
+      'keyword.type.c': palette.light.green10,
+      'support.function.builtin.zig': palette.light.orange9,
+      punctuation: lightTheme.text.tertiary,
     },
   },
 });


### PR DESCRIPTION
# How

Improve Rust and Zig syntax highlight, add related examples to the test bench. The changeset also includes small corrections for C# and Dart.

CC @byCedric 

# Preview

### Before

<table>
<tr>
<td>
<img height="300" alt="Screenshot 2026-01-12 090144" src="https://github.com/user-attachments/assets/760da054-3c95-4158-952f-a2f4a3b81879" />
</td>
</tr>
<tr>
<td>
<img  height="300" alt="Screenshot 2026-01-12 090019" src="https://github.com/user-attachments/assets/ae20a5b2-9034-407f-b2fa-2b346341203d" />

</td>
</tr>
<tr>
</table>

### After

<table>
<tr>
<td>
<img width="1462" height="913" alt="Screenshot 2026-01-12 004449" src="https://github.com/user-attachments/assets/17164c8d-f2df-4121-8d48-d33da0be2447" />

</td>
<td>
<img width="1436" height="914" alt="Screenshot 2026-01-12 004911" src="https://github.com/user-attachments/assets/9b245ff5-a97e-49f8-8728-f2fe9ca76b96" />

</td>
</tr>
<tr>
<td>
<img width="931" height="880" alt="Screenshot 2026-01-12 004522" src="https://github.com/user-attachments/assets/bd6b19e7-cb82-4c62-be48-07f6fbe3d971" />

</td>
<td>
<img width="1000" height="898" alt="Screenshot 2026-01-12 004856" src="https://github.com/user-attachments/assets/6b7b0ab3-b595-4322-b369-0229cb9741fb" />

</td>
</tr>
</table>